### PR TITLE
feat(trackpad): add mouse drag fix mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Trackpad modes:
 - `Default`: normal controller behavior with mouse available.
 - `Disabled`: turns off both trackpads.
 - `Directional Buttons`: left trackpad is D-pad, right trackpad is A/B/X/Y.
+- `Mouse Drag Fix`: keeps mouse behavior, but maps both right trackpad click zones to left click so dragging does not release when crossing into the original right-click zone; long press sends right click.
 
 ### Interface
 

--- a/main.py
+++ b/main.py
@@ -266,6 +266,7 @@ class DeckyZoneService:
         self._active_per_game_app_id = DEFAULT_APP_ID
         self._zotac_mouse_device_fd = None
         self._zotac_mouse_device_path = None
+        self._trackpad_latch_process = None
         self._brightness_dial_device_path = None
         self._brightness_dial_task = None
         self._brightness_dial_running = False
@@ -1106,6 +1107,78 @@ class DeckyZoneService:
             self._get_effective_trackpad_mode(app_id)
         )
 
+    def _should_enable_mouse_drag_fix_trackpads(self, app_id=None):
+        return trackpad_modes.is_trackpad_mode_mouse_drag_fix(
+            self._get_effective_trackpad_mode(app_id)
+        )
+
+    def _get_trackpad_latch_remapper_script_path(self):
+        return Path(decky.DECKY_PLUGIN_DIR) / "py_modules" / "zonepad_latch_remapper.py"
+
+    def _is_trackpad_latch_remapper_running(self):
+        return (
+            self._trackpad_latch_process is not None
+            and self._trackpad_latch_process.poll() is None
+        )
+
+    def _start_trackpad_latch_remapper(self):
+        if self._is_trackpad_latch_remapper_running():
+            return True
+
+        script_path = self._get_trackpad_latch_remapper_script_path()
+        if not script_path.is_file():
+            self.logger.warning(f"Trackpad latch remapper script missing: {script_path}")
+            return False
+
+        try:
+            self._trackpad_latch_process = subprocess.Popen(
+                [
+                    "/usr/bin/python3",
+                    str(script_path),
+                    "--release-delay-ms",
+                    "400",
+                    "--long-press-ms",
+                    "650",
+                    "--drag-threshold",
+                    "12",
+                    "--right-click-ms",
+                    "70",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except Exception as error:
+            self.logger.warning(f"Failed to start trackpad latch remapper: {error}")
+            self._trackpad_latch_process = None
+            return False
+
+        return True
+
+    def _stop_trackpad_latch_remapper(self):
+        process = self._trackpad_latch_process
+        if process is None:
+            return self._cleanup_step_result(changed=False)
+
+        changed = process.poll() is None
+        if changed:
+            process.terminate()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=2)
+
+        self._trackpad_latch_process = None
+        return self._cleanup_step_result(changed=changed)
+
+    def _sync_trackpad_latch_remapper_state(self, app_id=None):
+        if self._should_enable_mouse_drag_fix_trackpads(app_id):
+            return self._start_trackpad_latch_remapper()
+
+        self._stop_trackpad_latch_remapper()
+        return True
+
     def _get_effective_rumble_enabled(self, app_id=None):
         app_id = str(app_id or self._active_per_game_app_id or DEFAULT_APP_ID)
         global_enabled = self.settings_store.get_rumble_enabled()
@@ -1616,6 +1689,9 @@ class DeckyZoneService:
         if self._should_enable_directional_trackpads(app_id):
             return self._apply_directional_trackpad_button_mappings()
 
+        if self._should_enable_mouse_drag_fix_trackpads(app_id):
+            return self._apply_mouse_drag_fix_trackpad_button_mappings()
+
         return self._restore_directional_trackpad_button_mappings()
 
     def _should_enable_runtime_input_profile(self, app_id=None):
@@ -1982,12 +2058,16 @@ class DeckyZoneService:
 
         self._temporary_target_mode = None
         trackpad_result = self._sync_trackpad_suppression_state()
+        latch_result = self._sync_trackpad_latch_remapper_state(self._active_per_game_app_id)
         brightness_result = await self._sync_brightness_dial_fixer_state()
         rumble_result = await self._sync_rumble_state(self._active_per_game_app_id)
         profile_result = await self._sync_home_button_navigation_state()
 
         if not trackpad_result:
             return "Trackpad suppression state did not apply."
+
+        if not latch_result:
+            return "Trackpad latch remapper did not activate."
 
         if not brightness_result:
             return "Brightness dial listener did not activate."
@@ -2441,6 +2521,7 @@ class DeckyZoneService:
         )
         include_mouse = self._should_include_mouse_target(app_id)
         trackpad_result = self._sync_trackpad_suppression_state(app_id)
+        latch_result = self._sync_trackpad_latch_remapper_state(app_id)
         rumble_result = await self._sync_rumble_state(app_id)
 
         if button_prompt_fix_enabled:
@@ -2455,7 +2536,7 @@ class DeckyZoneService:
                 self._temporary_target_mode = MISSING_GLYPH_FIX_TARGET
                 await self._sync_brightness_dial_fixer_state()
                 profile_result = await self._sync_home_button_navigation_state()
-                return trackpad_result and rumble_result and profile_result
+                return trackpad_result and latch_result and rumble_result and profile_result
             except subprocess.CalledProcessError as error:
                 detail = (error.stderr or error.stdout or str(error)).strip()
                 self.logger.warning(f"Failed to apply per-game controller override: {detail}")
@@ -2488,7 +2569,7 @@ class DeckyZoneService:
                     return False
 
             profile_result = await self._sync_home_button_navigation_state()
-            return trackpad_result and rumble_result and profile_result
+            return trackpad_result and latch_result and rumble_result and profile_result
 
         try:
             if self.settings_store.get_startup_apply_enabled():
@@ -2505,8 +2586,8 @@ class DeckyZoneService:
                 await self._sync_brightness_dial_fixer_state()
                 await self._sync_rumble_state(app_id)
                 await self._sync_home_button_navigation_state()
-                return True
-            return True
+                return trackpad_result and latch_result
+            return trackpad_result and latch_result
         except subprocess.CalledProcessError as error:
             detail = (error.stderr or error.stdout or str(error)).strip()
             self.logger.warning(f"Failed to restore inherited controller target: {detail}")
@@ -2816,6 +2897,55 @@ class DeckyZoneService:
         except Exception as error:
             self.logger.warning(
                 f"Failed to apply directional trackpad mappings: {error}"
+            )
+            return False
+
+        return True
+
+    def _apply_mouse_drag_fix_trackpad_button_mappings(self):
+        device_path = self._resolve_zotac_command_hidraw_path()
+        if not device_path:
+            self.logger.warning(
+                "Unable to locate Zotac command HID node for mouse drag fix trackpad mode."
+            )
+            return False
+
+        desired_mappings = trackpad_modes.build_mouse_drag_fix_trackpad_button_payloads()
+
+        try:
+            current_mappings = self._get_touch_button_mappings(device_path)
+        except Exception as error:
+            self.logger.warning(
+                f"Failed to read current mouse drag fix trackpad mappings: {error}"
+            )
+            return False
+
+        backup_mappings = self._load_directional_trackpad_backup()
+        if backup_mappings is None:
+            if current_mappings == desired_mappings:
+                backup_mappings = trackpad_modes.build_default_trackpad_button_payloads()
+                self.logger.warning(
+                    "Mouse drag fix trackpad mappings were already active without a backup; "
+                    "using the observed Zotac defaults for restoration."
+                )
+            else:
+                backup_mappings = current_mappings
+            try:
+                self._store_directional_trackpad_backup(backup_mappings)
+            except Exception as error:
+                self.logger.warning(
+                    f"Failed to store mouse drag fix trackpad backup mappings: {error}"
+                )
+                return False
+
+        try:
+            for button_id, mapping_payload in desired_mappings.items():
+                if current_mappings.get(button_id) == mapping_payload:
+                    continue
+                self._set_zotac_button_mapping(device_path, mapping_payload)
+        except Exception as error:
+            self.logger.warning(
+                f"Failed to apply mouse drag fix trackpad mappings: {error}"
             )
             return False
 
@@ -3794,6 +3924,11 @@ class DeckyZoneService:
             "releaseTrackpadMouseGrab",
             self._release_zotac_mouse_device_for_reset,
         )
+        await self._run_cleanup_step(
+            steps,
+            "stopTrackpadLatchRemapper",
+            self._stop_trackpad_latch_remapper,
+        )
         gyro_mount_matrix_step = await self._run_cleanup_step(
             steps,
             "removeGyroMountMatrixFix",
@@ -3870,6 +4005,11 @@ class DeckyZoneService:
             steps,
             "releaseTrackpadMouseGrab",
             self._release_zotac_mouse_device_cleanup_result,
+        )
+        await self._run_cleanup_step(
+            steps,
+            "stopTrackpadLatchRemapper",
+            self._stop_trackpad_latch_remapper,
         )
         await self._run_cleanup_step(
             steps,

--- a/py_modules/trackpad_modes.py
+++ b/py_modules/trackpad_modes.py
@@ -2,12 +2,14 @@ TRACKPAD_MODE_DEFAULT = "default"
 LEGACY_TRACKPAD_MODE_MOUSE = "mouse"
 TRACKPAD_MODE_DISABLED = "disabled"
 TRACKPAD_MODE_DIRECTIONAL_BUTTONS = "directional_buttons"
+TRACKPAD_MODE_MOUSE_DRAG_FIX = "mouse_drag_fix"
 
 DEFAULT_TRACKPAD_MODE = TRACKPAD_MODE_DEFAULT
 VALID_TRACKPAD_MODES = {
     TRACKPAD_MODE_DEFAULT,
     TRACKPAD_MODE_DISABLED,
     TRACKPAD_MODE_DIRECTIONAL_BUTTONS,
+    TRACKPAD_MODE_MOUSE_DRAG_FIX,
 }
 
 DIRECTIONAL_CAPABILITY_MAP_ID = "deckyzone_zone_trackpad_directional"
@@ -44,6 +46,17 @@ ZOTAC_TOUCH_BUTTON_DEFAULT_MAPPINGS = (
     ("Right Touch Down", 0x08, (), ()),
     ("Right Touch Left", 0x09, (), ("left",)),
     ("Right Touch Right", 0x0A, (), ("right",)),
+)
+
+ZOTAC_TOUCH_BUTTON_MOUSE_DRAG_FIX_MAPPINGS = (
+    ("Left Touch Up", 0x03, (), ()),
+    ("Left Touch Down", 0x04, (), ()),
+    ("Left Touch Left", 0x05, (), ()),
+    ("Left Touch Right", 0x06, (), ()),
+    ("Right Touch Up", 0x07, (), ()),
+    ("Right Touch Down", 0x08, (), ()),
+    ("Right Touch Left", 0x09, (), ("left",)),
+    ("Right Touch Right", 0x0A, (), ("left",)),
 )
 
 ZOTAC_GAMEPAD_BUTTON_BITS = {
@@ -95,6 +108,10 @@ def is_trackpad_mode_directional(mode):
     return normalize_trackpad_mode(mode) == TRACKPAD_MODE_DIRECTIONAL_BUTTONS
 
 
+def is_trackpad_mode_mouse_drag_fix(mode):
+    return normalize_trackpad_mode(mode) == TRACKPAD_MODE_MOUSE_DRAG_FIX
+
+
 def _build_zotac_button_mapping_payload(
     source_button_id,
     *,
@@ -140,4 +157,15 @@ def build_default_trackpad_button_payloads():
             mouse_buttons=tuple(mouse_buttons),
         )
         for _, source_button_id, gamepad_buttons, mouse_buttons in ZOTAC_TOUCH_BUTTON_DEFAULT_MAPPINGS
+    }
+
+
+def build_mouse_drag_fix_trackpad_button_payloads():
+    return {
+        source_button_id: _build_zotac_button_mapping_payload(
+            source_button_id,
+            gamepad_buttons=tuple(gamepad_buttons),
+            mouse_buttons=tuple(mouse_buttons),
+        )
+        for _, source_button_id, gamepad_buttons, mouse_buttons in ZOTAC_TOUCH_BUTTON_MOUSE_DRAG_FIX_MAPPINGS
     }

--- a/py_modules/zonepad_latch_remapper.py
+++ b/py_modules/zonepad_latch_remapper.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+import argparse
+import asyncio
+import contextlib
+import signal
+import time
+
+from evdev import AbsInfo, InputDevice, UInput, ecodes, list_devices
+
+
+DEFAULT_DEVICE_NAME = "ZOTAC Gaming Zone Mouse"
+DEFAULT_RELEASE_DELAY_MS = 400
+DEFAULT_LONG_PRESS_MS = 650
+DEFAULT_DRAG_THRESHOLD = 12
+DEFAULT_RIGHT_CLICK_MS = 70
+
+
+def find_device_path(name):
+    for path in list_devices():
+        try:
+            device = InputDevice(path)
+        except OSError:
+            continue
+        if device.name == name:
+            return path
+    return None
+
+
+def signed_rel(value):
+    if value >= 2**31:
+        return value - 2**32
+    return value
+
+
+def build_capabilities(source):
+    caps = source.capabilities(absinfo=True)
+    result = {}
+    for event_type, codes in caps.items():
+        if event_type == ecodes.EV_SYN:
+            continue
+        if event_type == ecodes.EV_KEY:
+            result[event_type] = [
+                code for code in codes
+                if isinstance(code, int) and ecodes.BTN_MOUSE <= code <= ecodes.BTN_TASK
+            ]
+        elif event_type == ecodes.EV_REL:
+            result[event_type] = [code for code in codes if isinstance(code, int)]
+        elif event_type == ecodes.EV_ABS:
+            abs_codes = []
+            for code, info in codes:
+                if isinstance(info, AbsInfo):
+                    abs_codes.append((code, info))
+            if abs_codes:
+                result[event_type] = abs_codes
+    return {event_type: codes for event_type, codes in result.items() if codes}
+
+
+class LeftButtonLatch:
+    def __init__(
+        self,
+        ui,
+        delay_seconds,
+        long_press_seconds,
+        right_click_seconds,
+        drag_threshold,
+        verbose=False,
+    ):
+        self.ui = ui
+        self.delay_seconds = delay_seconds
+        self.long_press_seconds = long_press_seconds
+        self.right_click_seconds = right_click_seconds
+        self.drag_threshold = drag_threshold
+        self.verbose = verbose
+        self.left_down = False
+        self.press_pending = False
+        self.suppress_until_release = False
+        self.pending_long_press = None
+        self.pending_motion = 0
+        self.pending_release = None
+        self.pending_started_at = None
+
+    def log(self, message):
+        line = f"{time.monotonic():.6f} {message}"
+        if self.verbose:
+            print(line, flush=True)
+
+    def cancel_pending_release(self):
+        if self.pending_release is None:
+            return
+        self.pending_release.cancel()
+        self.pending_release = None
+        self.pending_started_at = None
+        self.log("cancel delayed BTN_LEFT up")
+
+    def cancel_pending_long_press(self):
+        if self.pending_long_press is None:
+            return
+        self.pending_long_press.cancel()
+        self.pending_long_press = None
+
+    def emit_left_down(self):
+        self.cancel_pending_long_press()
+        self.press_pending = False
+        self.suppress_until_release = False
+        if self.left_down:
+            return
+        self.left_down = True
+        self.ui.write(ecodes.EV_KEY, ecodes.BTN_LEFT, 1)
+        self.ui.syn()
+        self.log("emit BTN_LEFT=1")
+
+    async def emit_right_click(self):
+        self.ui.write(ecodes.EV_KEY, ecodes.BTN_RIGHT, 1)
+        self.ui.syn()
+        self.log("emit BTN_RIGHT=1")
+        await asyncio.sleep(self.right_click_seconds)
+        self.ui.write(ecodes.EV_KEY, ecodes.BTN_RIGHT, 0)
+        self.ui.syn()
+        self.log("emit BTN_RIGHT=0")
+
+    async def long_press(self):
+        try:
+            await asyncio.sleep(self.long_press_seconds)
+            if not self.press_pending:
+                return
+            self.press_pending = False
+            self.pending_long_press = None
+            self.suppress_until_release = True
+            self.log("long press -> right click")
+            await self.emit_right_click()
+        except asyncio.CancelledError:
+            raise
+
+    async def delayed_release(self):
+        try:
+            await asyncio.sleep(self.delay_seconds)
+            self.left_down = False
+            self.pending_release = None
+            elapsed_ms = (time.monotonic() - self.pending_started_at) * 1000
+            self.pending_started_at = None
+            self.ui.write(ecodes.EV_KEY, ecodes.BTN_LEFT, 0)
+            self.ui.syn()
+            self.log(f"emit delayed BTN_LEFT=0 after {elapsed_ms:.1f}ms")
+        except asyncio.CancelledError:
+            raise
+
+    def handle_left(self, value):
+        if value:
+            if self.pending_release is not None:
+                self.cancel_pending_release()
+                self.left_down = True
+                return
+            if self.left_down or self.press_pending:
+                return
+            self.press_pending = True
+            self.suppress_until_release = False
+            self.pending_motion = 0
+            self.pending_long_press = asyncio.create_task(self.long_press())
+            self.log("pending BTN_LEFT down")
+            return
+
+        if self.press_pending:
+            self.cancel_pending_long_press()
+            self.press_pending = False
+            self.ui.write(ecodes.EV_KEY, ecodes.BTN_LEFT, 1)
+            self.ui.syn()
+            self.ui.write(ecodes.EV_KEY, ecodes.BTN_LEFT, 0)
+            self.ui.syn()
+            self.log("emit BTN_LEFT tap")
+            return
+
+        if self.suppress_until_release:
+            self.suppress_until_release = False
+            self.log("suppress BTN_LEFT release after right click")
+            return
+
+        if not self.left_down:
+            return
+        if self.pending_release is not None:
+            return
+        self.pending_started_at = time.monotonic()
+        self.pending_release = asyncio.create_task(self.delayed_release())
+        self.log("delay BTN_LEFT=0")
+
+    def handle_motion(self, value):
+        if not self.press_pending:
+            return
+        self.pending_motion += abs(value)
+        if self.pending_motion >= self.drag_threshold:
+            self.log(f"motion threshold {self.pending_motion} -> left drag")
+            self.emit_left_down()
+
+    async def flush(self):
+        self.cancel_pending_long_press()
+        self.press_pending = False
+        self.suppress_until_release = False
+        self.cancel_pending_release()
+        if self.left_down:
+            self.left_down = False
+            self.ui.write(ecodes.EV_KEY, ecodes.BTN_LEFT, 0)
+            self.ui.syn()
+            self.log("flush BTN_LEFT=0")
+
+
+async def run(args):
+    path = args.device or find_device_path(args.name)
+    if not path:
+        raise SystemExit(f"Unable to find input device named {args.name!r}")
+
+    source = InputDevice(path)
+    caps = build_capabilities(source)
+    ui = UInput(caps, name=args.output_name, phys="zonepad-latch/input0")
+
+    latch = LeftButtonLatch(
+        ui,
+        args.release_delay_ms / 1000,
+        args.long_press_ms / 1000,
+        args.right_click_ms / 1000,
+        args.drag_threshold,
+        verbose=args.verbose,
+    )
+    stop = asyncio.Event()
+
+    def request_stop():
+        stop.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError):
+            loop.add_signal_handler(sig, request_stop)
+
+    print(f"source={source.path} {source.name}")
+    output_path = getattr(getattr(ui, "device", None), "path", None) or "/dev/uinput"
+    print(f"output={output_path} {args.output_name}")
+    print(f"release_delay_ms={args.release_delay_ms}")
+    print(f"long_press_ms={args.long_press_ms}")
+    print(f"drag_threshold={args.drag_threshold}")
+    print("grabbing source device; Ctrl+C to stop")
+    latch.log(
+        "started "
+        f"source={source.path} "
+        f"release_delay_ms={args.release_delay_ms} "
+        f"long_press_ms={args.long_press_ms} "
+        f"drag_threshold={args.drag_threshold} "
+        f"right_click_ms={args.right_click_ms}"
+    )
+    source.grab()
+
+    async def read_events():
+        async for event in source.async_read_loop():
+            if event.type == ecodes.EV_SYN:
+                continue
+
+            if event.type == ecodes.EV_KEY and event.code == ecodes.BTN_LEFT:
+                latch.handle_left(event.value)
+                continue
+
+            if event.type == ecodes.EV_REL:
+                value = signed_rel(event.value)
+                latch.handle_motion(value)
+                if value:
+                    ui.write(event.type, event.code, value)
+                    ui.syn()
+                continue
+
+            ui.write(event.type, event.code, event.value)
+            ui.syn()
+
+    reader = asyncio.create_task(read_events())
+    stopper = asyncio.create_task(stop.wait())
+    try:
+        done, pending = await asyncio.wait(
+            {reader, stopper},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in done:
+            if task is reader:
+                task.result()
+    finally:
+        reader.cancel()
+        stopper.cancel()
+        with contextlib.suppress(Exception):
+            await latch.flush()
+        with contextlib.suppress(Exception):
+            source.ungrab()
+        ui.close()
+        source.close()
+        print("stopped")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", help="source evdev path, default: auto-detect Zotac mouse")
+    parser.add_argument("--name", default=DEFAULT_DEVICE_NAME)
+    parser.add_argument("--output-name", default="ZonePad Drag Fix Mouse")
+    parser.add_argument("--release-delay-ms", type=int, default=DEFAULT_RELEASE_DELAY_MS)
+    parser.add_argument("--long-press-ms", type=int, default=DEFAULT_LONG_PRESS_MS)
+    parser.add_argument("--drag-threshold", type=int, default=DEFAULT_DRAG_THRESHOLD)
+    parser.add_argument("--right-click-ms", type=int, default=DEFAULT_RIGHT_CLICK_MS)
+    parser.add_argument("--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    asyncio.run(run(parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/components/controller/TrackpadPanel.tsx
+++ b/src/components/controller/TrackpadPanel.tsx
@@ -18,6 +18,7 @@ const TRACKPAD_MODE_OPTIONS: TrackpadModeOption[] = [
   { data: 'default', label: 'Default' },
   { data: 'disabled', label: 'Disabled' },
   { data: 'directional_buttons', label: 'Directional Buttons' },
+  { data: 'mouse_drag_fix', label: 'Mouse Drag Fix' },
 ]
 
 function getTrackpadModeDescription(mode: TrackpadMode) {
@@ -26,6 +27,8 @@ function getTrackpadModeDescription(mode: TrackpadMode) {
       return 'Turns off both trackpads'
     case 'directional_buttons':
       return 'Left pad is D-pad, right pad is A/B/X/Y'
+    case 'mouse_drag_fix':
+      return 'Keeps left-button drags active across the right pad click zones and uses long press for right click'
     case 'default':
     default:
       return 'Normal controller behavior with mouse available'

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -4,7 +4,7 @@ export type PluginStatus = {
 }
 
 export type ControllerMode = 'gamepad' | 'desktop'
-export type TrackpadMode = 'default' | 'disabled' | 'directional_buttons'
+export type TrackpadMode = 'default' | 'disabled' | 'directional_buttons' | 'mouse_drag_fix'
 
 export type GyroMountMatrixFixState = {
   visible: boolean


### PR DESCRIPTION
## Summary

This PR adds a new `Mouse Drag Fix` trackpad mode to improve the current trackpad mouse experience on the ZOTAC Gaming Zone.

The existing default trackpad mouse simulation is exposed as a regular HID mouse, with fixed left/right click zones on the trackpads. In practice, this makes click-and-drag interactions **horrible**: dragging can be interrupted when crossing into the original right-click zone, and the overall behavior feels unreliable for normal mouse-style use.

The new mode keeps mouse movement available, maps the right trackpad click zones to left click for more reliable dragging, and uses a long press gesture to preserve access to right click.

## Why

I noticed that the [inputplumber](https://github.com/ShadowBlip/InputPlumber) repository has a TODO to improve this after ABS mode firmware is applied to the trackpads. However, future ZOTAC support for this device is uncertain, and given the current handheld PC market situation, it seems unlikely that a ZOTAC Zone 2 or related firmware work will arrive soon.

Because of that, I implemented this workaround so current ZOTAC Gaming Zone users can have a better trackpad mouse experience today. I hope this is useful for other users with the same device.

## Development note

The code was written with AI assistance, but I reviewed the implementation, tested it on my own device, and am currently using it in daily use.

Based on that review and testing, I also identified the dependency caution around `evdev` and the future tuning points described below.

## Changes

- Add a new `mouse_drag_fix` trackpad mode.
- Add `zonepad_latch_remapper.py`, an evdev/uinput-based helper for improving drag behavior.
- Start and stop the helper automatically when Mouse Drag Fix mode is enabled or disabled.
- Add backend button mapping payloads for the new mode.
- Expose the new mode in the controller UI.
- Update the TypeScript trackpad mode type.
- Document the new mode in the README.

## Dependency note

`zonepad_latch_remapper.py` depends on the Python `evdev` module.

It appears to be installed by default with Decky Loader, but if this causes issues in distribution or fresh installs, we may need to add an explicit dependency/bootstrap step for `evdev`.

## Future tuning points

The current timing and movement thresholds are fixed defaults, but the remapper already accepts parameters that could be exposed later if user-level tuning becomes useful.

Potential tuning parameters include:

- `release-delay-ms`
- `long-press-ms`
- `drag-threshold`
- `right-click-ms`

These could be exposed in the UI to let users adjust drag release latency, long-press timing, and movement sensitivity.