### PR TITLE
Add Fix Sleep toggle for SteamOS AMD IOMMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Display changes require a reboot after toggling them. `HDR / Washed out colors` 
 | --------- | -------------- | ------- | ------ | ------- |
 | Fix Sleep | ❓             | ❌      | ❌      | ❌      |
 
-Fix Sleep removes SteamOS's `amd_iommu=off` boot argument, allowing AMD IOMMU on the ZOTAC ZONE. It requires a restart and reports both the saved GRUB configuration and whether the running kernel command line still disables AMD IOMMU.
+Fix Sleep removes SteamOS's `amd_iommu=off` boot argument, allowing AMD IOMMU on the ZOTAC ZONE. It requires a restart and reports the configured GRUB state and whether the running kernel command line still disables AMD IOMMU.
 
 ## Compatibility Notes
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ Zotac Glyphs applies Zotac controller button glyphs and controller images in Ste
 
 Display changes require a reboot after toggling them. `HDR / Washed out colors` was fixed out of the box in my SteamOS `main`, SteamOS 3.8.1 Preview, Bazzite, Nobara, and CachyOS testing.
 
+### Power
+
+| Feature   | SteamOS `main` | Bazzite | Nobara | CachyOS |
+| --------- | -------------- | ------- | ------ | ------- |
+| Fix Sleep | ❓             | ❌      | ❌      | ❌      |
+
+Fix Sleep removes SteamOS's `amd_iommu=off` boot argument, allowing AMD IOMMU on the ZOTAC ZONE. It requires a restart and reports both the saved GRUB configuration and whether the running kernel command line still disables AMD IOMMU.
+
 ## Compatibility Notes
 
 Controller features rely on InputPlumber and Zotac input/HID support. Non-SteamOS compatibility depends on what that OS image currently ships and exposes to Decky Loader.

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ import inputplumber_target_sync
 import plugin_update
 import plugin_settings
 import runtime_profile_utils
+import steamos_sleep_fix
 import trackpad_modes
 
 gamescope_display_profiles = gamescope_display_profiles_module
@@ -244,6 +245,7 @@ class DeckyZoneService:
         read_text=None,
         settings_store=plugin_settings,
         gamescope_display_profiles=None,
+        sleep_fix=None,
     ):
         self.command_runner = command_runner
         self.sleep = sleep
@@ -256,6 +258,11 @@ class DeckyZoneService:
                 user_home=decky.DECKY_USER_HOME,
                 plugin_dir=decky.DECKY_PLUGIN_DIR,
             )
+        )
+        self.sleep_fix = sleep_fix or steamos_sleep_fix.SteamOSSleepFix(
+            command_runner=command_runner,
+            runtime_dir=decky.DECKY_PLUGIN_RUNTIME_DIR,
+            env=self.get_env(),
         )
         self._status = {"state": "idle", "message": DBUS_READY_MESSAGE}
         self._privilege_context_logged = False
@@ -727,12 +734,14 @@ class DeckyZoneService:
     def _current_settings(self):
         display_profile_settings = self._get_display_profile_settings()
         controller_mode_snapshot = self._get_controller_mode_snapshot()
+        sleep_fix_state = self._get_sleep_fix_state()
         return {
             "startupApplyEnabled": self.settings_store.get_startup_apply_enabled(),
             "controllerMode": controller_mode_snapshot["mode"],
             "controllerModeAvailable": controller_mode_snapshot["available"],
             "homeButtonEnabled": self.settings_store.get_home_button_enabled(),
             "brightnessDialFixEnabled": self.settings_store.get_brightness_dial_fix_enabled(),
+            "sleepFix": sleep_fix_state,
             "gyroMountMatrixFix": self._get_gyro_mount_matrix_fix_state(),
             "trackpadMode": self.settings_store.get_trackpad_mode(),
             "zotacGlyphsEnabled": self.settings_store.get_zotac_glyphs_enabled(),
@@ -747,6 +756,56 @@ class DeckyZoneService:
             "rumbleIntensity": self.settings_store.get_rumble_intensity(),
             "rumbleAvailable": self._rumble_available,
             "perGameSettings": self.settings_store.get_per_game_settings(),
+        }
+
+    def _get_sleep_fix_state(self):
+        desired_enabled = self.settings_store.get_fix_sleep_enabled()
+        state = self.sleep_fix.get_state()
+        config_iommu_disabled = state["configIommuDisabled"]
+        runtime_iommu_disabled = state["runtimeIommuDisabled"]
+        available = bool(state["available"])
+        reboot_required = bool(
+            isinstance(config_iommu_disabled, bool)
+            and isinstance(runtime_iommu_disabled, bool)
+            and config_iommu_disabled != runtime_iommu_disabled
+        )
+
+        if not available:
+            status = "unavailable"
+            message = state["message"] or "Fix Sleep is unavailable."
+        elif desired_enabled and config_iommu_disabled:
+            status = "configuration_drift"
+            message = "AMD IOMMU is disabled in the SteamOS boot configuration."
+        elif desired_enabled and reboot_required:
+            status = "pending_reboot"
+            message = "AMD IOMMU boot configuration is updated. Restart required."
+        elif runtime_iommu_disabled is None:
+            status = "configured"
+            message = state["message"] or "AMD IOMMU runtime state is unavailable."
+        elif desired_enabled and runtime_iommu_disabled is False:
+            status = "active"
+            message = "The current boot does not disable AMD IOMMU."
+        elif not desired_enabled and config_iommu_disabled is False:
+            status = "configuration_drift"
+            message = "AMD IOMMU is not disabled in the SteamOS boot configuration."
+        elif reboot_required:
+            status = "pending_reboot"
+            message = "AMD IOMMU boot configuration is updated. Restart required."
+        elif runtime_iommu_disabled is True:
+            status = "disabled"
+            message = "The current boot disables AMD IOMMU."
+        else:
+            status = "configured"
+            message = "AMD IOMMU boot configuration matches the saved setting."
+
+        return {
+            "enabled": desired_enabled,
+            "available": available,
+            "configuredIommuDisabled": config_iommu_disabled,
+            "runtimeIommuDisabled": runtime_iommu_disabled,
+            "rebootRequired": reboot_required,
+            "status": status,
+            "message": message,
         }
 
     def get_env(self):
@@ -3275,6 +3334,46 @@ class DeckyZoneService:
 
         return self._current_settings()
 
+    async def set_fix_sleep_enabled(self, enabled):
+        enabled = bool(enabled)
+        current_enabled = self.settings_store.get_fix_sleep_enabled()
+        state = self.sleep_fix.get_state()
+        if not state["available"]:
+            raise RuntimeError(state["message"] or "Fix Sleep is unavailable.")
+
+        if enabled:
+            if not current_enabled:
+                self.settings_store.set_fix_sleep_original_amd_iommu_off(
+                    bool(state["configIommuDisabled"])
+                )
+
+            try:
+                self.sleep_fix.apply_iommu_disabled(False)
+            except steamos_sleep_fix.SleepFixConfigurationError as error:
+                raise RuntimeError(str(error)) from error
+
+            self.settings_store.set_fix_sleep_enabled(True)
+            return self._current_settings()
+
+        original_iommu_disabled = (
+            self.settings_store.get_fix_sleep_original_amd_iommu_off()
+        )
+        if original_iommu_disabled is None:
+            if current_enabled:
+                raise RuntimeError(
+                    "DeckyZone cannot safely restore the original AMD IOMMU setting."
+                )
+            return self._current_settings()
+
+        try:
+            self.sleep_fix.apply_iommu_disabled(original_iommu_disabled)
+        except steamos_sleep_fix.SleepFixConfigurationError as error:
+            raise RuntimeError(str(error)) from error
+
+        self.settings_store.set_fix_sleep_enabled(False)
+        self.settings_store.clear_fix_sleep_original_amd_iommu_off()
+        return self._current_settings()
+
     async def set_gyro_mount_matrix_fix_enabled(self, enabled):
         state = self._get_gyro_mount_matrix_fix_state()
         if enabled:
@@ -3757,6 +3856,22 @@ class DeckyZoneService:
         self.settings_store.reset_settings()
         return self._cleanup_step_result(changed=True)
 
+    def _skip_settings_reset_for_sleep_fix_failure(self):
+        return self._cleanup_step_result(
+            ok=False,
+            message="Skipped because the original AMD IOMMU setting was not restored.",
+        )
+
+    async def _restore_sleep_fix_for_reset(self):
+        if not self.settings_store.get_fix_sleep_enabled():
+            return self._cleanup_step_result()
+
+        await self.set_fix_sleep_enabled(False)
+        return self._cleanup_step_result(
+            changed=True,
+            message="Restored the original AMD IOMMU setting. Restart required.",
+        )
+
     async def reset_plugin_state(self):
         steps = []
         force_inputplumber_restart = bool(
@@ -3768,6 +3883,11 @@ class DeckyZoneService:
             steps,
             "stopControllerModeMonitor",
             self.stop_controller_mode_monitor,
+        )
+        sleep_fix_step = await self._run_cleanup_step(
+            steps,
+            "restoreSleepFix",
+            self._restore_sleep_fix_for_reset,
         )
         await self._run_cleanup_step(
             steps,
@@ -3824,11 +3944,18 @@ class DeckyZoneService:
             "removeGamescopeDisplayProfiles",
             self._cleanup_gamescope_display_profiles_for_reset,
         )
-        await self._run_cleanup_step(
-            steps,
-            "resetSettings",
-            self._reset_settings_for_reset,
-        )
+        if sleep_fix_step["ok"]:
+            await self._run_cleanup_step(
+                steps,
+                "resetSettings",
+                self._reset_settings_for_reset,
+            )
+        else:
+            await self._run_cleanup_step(
+                steps,
+                "resetSettings",
+                self._skip_settings_reset_for_sleep_fix_failure,
+            )
 
         self._set_status("disabled", DISABLED_MESSAGE)
         ok = all(step["ok"] for step in steps)
@@ -4109,6 +4236,9 @@ class Plugin:
 
     async def set_brightness_dial_fix_enabled(self, enabled):
         return await self.service.set_brightness_dial_fix_enabled(enabled)
+
+    async def set_fix_sleep_enabled(self, enabled):
+        return await self.service.set_fix_sleep_enabled(enabled)
 
     async def set_gyro_mount_matrix_fix_enabled(self, enabled):
         return await self.service.set_gyro_mount_matrix_fix_enabled(enabled)

--- a/py_modules/plugin_settings.py
+++ b/py_modules/plugin_settings.py
@@ -7,6 +7,8 @@ import trackpad_modes
 STARTUP_APPLY_KEY = "startupApplyEnabled"
 HOME_BUTTON_ENABLED_KEY = "homeButtonEnabled"
 BRIGHTNESS_DIAL_FIX_ENABLED_KEY = "brightnessDialFixEnabled"
+FIX_SLEEP_ENABLED_KEY = "fixSleepEnabled"
+FIX_SLEEP_ORIGINAL_AMD_IOMMU_OFF_KEY = "fixSleepOriginalAmdIommuOff"
 TRACKPAD_MODE_KEY = "trackpadMode"
 LEGACY_TRACKPADS_DISABLED_KEY = "trackpadsDisabled"
 ZOTAC_GLYPHS_ENABLED_KEY = "zotacGlyphsEnabled"
@@ -25,6 +27,7 @@ M2_REMAP_TARGET_KEY = "m2RemapTarget"
 DEFAULT_STARTUP_APPLY_ENABLED = False
 DEFAULT_HOME_BUTTON_ENABLED = False
 DEFAULT_BRIGHTNESS_DIAL_FIX_ENABLED = False
+DEFAULT_FIX_SLEEP_ENABLED = False
 DEFAULT_TRACKPAD_MODE = trackpad_modes.DEFAULT_TRACKPAD_MODE
 DEFAULT_ZOTAC_GLYPHS_ENABLED = False
 DEFAULT_RUMBLE_ENABLED = False
@@ -231,6 +234,33 @@ def get_brightness_dial_fix_enabled():
 def set_brightness_dial_fix_enabled(enabled):
     _write_setting(BRIGHTNESS_DIAL_FIX_ENABLED_KEY, bool(enabled))
     return get_brightness_dial_fix_enabled()
+
+
+def get_fix_sleep_enabled():
+    settings = _read_settings()
+    return bool(settings.get(FIX_SLEEP_ENABLED_KEY, DEFAULT_FIX_SLEEP_ENABLED))
+
+
+def set_fix_sleep_enabled(enabled):
+    _write_setting(FIX_SLEEP_ENABLED_KEY, bool(enabled))
+    return get_fix_sleep_enabled()
+
+
+def get_fix_sleep_original_amd_iommu_off():
+    settings = _read_settings()
+    value = settings.get(FIX_SLEEP_ORIGINAL_AMD_IOMMU_OFF_KEY)
+    return value if isinstance(value, bool) else None
+
+
+def set_fix_sleep_original_amd_iommu_off(disabled):
+    _write_setting(FIX_SLEEP_ORIGINAL_AMD_IOMMU_OFF_KEY, bool(disabled))
+    return get_fix_sleep_original_amd_iommu_off()
+
+
+def clear_fix_sleep_original_amd_iommu_off():
+    setting_file.read()
+    setting_file.settings.pop(FIX_SLEEP_ORIGINAL_AMD_IOMMU_OFF_KEY, None)
+    setting_file.commit()
 
 
 def get_trackpad_mode():

--- a/py_modules/steamos_sleep_fix.py
+++ b/py_modules/steamos_sleep_fix.py
@@ -1,0 +1,298 @@
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+STEAMOS_OS_RELEASE_PATHS = (Path("/etc/os-release"), Path("/usr/lib/os-release"))
+GRUB_DEFAULT_PATH = Path("/etc/default/grub-steamos")
+GRUB_CONFIG_PATH = Path("/boot/efi/EFI/steamos/grub.cfg")
+GRUB_MKCONFIG_PATH = Path("/usr/bin/grub-mkconfig")
+RUNTIME_CMDLINE_PATH = Path("/proc/cmdline")
+ORIGINAL_GRUB_BACKUP_FILENAME = "grub-steamos-before-deckyzone"
+AMD_IOMMU_OFF = "amd_iommu=off"
+
+_CMDLINE_ASSIGNMENT_RE = re.compile(
+    r'(?m)^(?P<prefix>[ \t]*GRUB_CMDLINE_LINUX=")'
+    r'(?P<body>.*?)'
+    r'(?P<closing>^[ \t]*"[ \t]*(?:#.*)?(?:\r?\n|$))',
+    re.DOTALL,
+)
+_AMD_IOMMU_OFF_RE = re.compile(r"(?<!\S)amd_iommu=off(?!\S)")
+
+
+class SleepFixConfigurationError(RuntimeError):
+    pass
+
+
+def parse_os_release(content):
+    values = {}
+    for raw_line in (content or "").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if (
+            len(value) >= 2
+            and value[0] == value[-1]
+            and value[0] in {"'", '"'}
+        ):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def is_steamos_os_release(content):
+    return parse_os_release(content).get("ID", "").lower() == "steamos"
+
+
+def has_amd_iommu_off(content):
+    return bool(_AMD_IOMMU_OFF_RE.search(content or ""))
+
+
+def _get_cmdline_assignment(content):
+    matches = list(_CMDLINE_ASSIGNMENT_RE.finditer(content or ""))
+    if len(matches) != 1:
+        raise SleepFixConfigurationError(
+            "Expected exactly one GRUB_CMDLINE_LINUX assignment."
+        )
+
+    match = matches[0]
+    body = match.group("body")
+    if "\n" not in body:
+        raise SleepFixConfigurationError(
+            "GRUB_CMDLINE_LINUX is not in the expected multiline format."
+        )
+
+    last_line = next(
+        (line for line in reversed(body.splitlines()) if line.strip()), None
+    )
+    if last_line is None or not last_line.rstrip().endswith("\\"):
+        raise SleepFixConfigurationError(
+            "GRUB_CMDLINE_LINUX does not end with an escaped continuation line."
+        )
+
+    return match
+
+
+def _remove_amd_iommu_off(body):
+    # Prefer removing a complete argument line so the known SteamOS layout stays
+    # readable. The token replacement covers uncommon inline layouts as well.
+    body = re.sub(
+        r"(?m)^[ \t]*amd_iommu=off[ \t]*\\[ \t]*(?:\r?\n|$)",
+        "",
+        body,
+    )
+    return _AMD_IOMMU_OFF_RE.sub("", body)
+
+
+def set_amd_iommu_disabled(grub_defaults, disabled):
+    match = _get_cmdline_assignment(grub_defaults)
+    body = match.group("body")
+    off_count = len(_AMD_IOMMU_OFF_RE.findall(body))
+
+    if disabled and off_count == 1:
+        return grub_defaults, False
+    if not disabled and off_count == 0:
+        return grub_defaults, False
+
+    updated_body = _remove_amd_iommu_off(body)
+    if disabled:
+        last_line = next(
+            line for line in reversed(updated_body.splitlines()) if line.strip()
+        )
+        indentation = re.match(r"^[ \t]*", last_line).group(0)
+        newline = "\r\n" if "\r\n" in updated_body else "\n"
+        updated_body = f"{updated_body}{indentation}{AMD_IOMMU_OFF} \\{newline}"
+
+    updated = (
+        grub_defaults[: match.start("body")]
+        + updated_body
+        + grub_defaults[match.end("body") :]
+    )
+    return updated, updated != grub_defaults
+
+
+class SteamOSSleepFix:
+    def __init__(
+        self,
+        command_runner=subprocess.run,
+        runtime_dir=None,
+        env=None,
+        os_release_paths=STEAMOS_OS_RELEASE_PATHS,
+        grub_default_path=GRUB_DEFAULT_PATH,
+        grub_config_path=GRUB_CONFIG_PATH,
+        grub_mkconfig_path=GRUB_MKCONFIG_PATH,
+        runtime_cmdline_path=RUNTIME_CMDLINE_PATH,
+    ):
+        self.command_runner = command_runner
+        self.runtime_dir = Path(runtime_dir) if runtime_dir else None
+        self.env = env
+        self.os_release_paths = tuple(Path(path) for path in os_release_paths)
+        self.grub_default_path = Path(grub_default_path)
+        self.grub_config_path = Path(grub_config_path)
+        self.grub_mkconfig_path = Path(grub_mkconfig_path)
+        self.runtime_cmdline_path = Path(runtime_cmdline_path)
+
+    def _read_os_release(self):
+        for path in self.os_release_paths:
+            try:
+                return path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+        raise SleepFixConfigurationError("SteamOS os-release metadata is unavailable.")
+
+    def _validate_paths(self):
+        if not is_steamos_os_release(self._read_os_release()):
+            raise SleepFixConfigurationError("Fix Sleep is only supported on SteamOS.")
+
+        for path, label in (
+            (self.grub_default_path, "SteamOS GRUB defaults"),
+            (self.grub_config_path, "generated SteamOS GRUB configuration"),
+        ):
+            if path.is_symlink() or not path.is_file():
+                raise SleepFixConfigurationError(f"Expected {label} is unavailable.")
+
+        if not self.grub_mkconfig_path.is_file() or not os.access(
+            self.grub_mkconfig_path, os.X_OK
+        ):
+            raise SleepFixConfigurationError("/usr/bin/grub-mkconfig is unavailable.")
+
+    def _read_grub_defaults(self):
+        self._validate_paths()
+        try:
+            content = self.grub_default_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            raise SleepFixConfigurationError(
+                f"Failed to read SteamOS GRUB defaults: {error}"
+            ) from error
+        _get_cmdline_assignment(content)
+        return content
+
+    def get_state(self):
+        state = {
+            "available": False,
+            "message": "",
+            "configIommuDisabled": None,
+            "runtimeIommuDisabled": None,
+        }
+        try:
+            grub_defaults = self._read_grub_defaults()
+            state["available"] = True
+            state["configIommuDisabled"] = has_amd_iommu_off(grub_defaults)
+        except SleepFixConfigurationError as error:
+            state["message"] = str(error)
+            return state
+
+        try:
+            cmdline = self.runtime_cmdline_path.read_text(encoding="utf-8")
+            state["runtimeIommuDisabled"] = has_amd_iommu_off(cmdline)
+        except (OSError, UnicodeDecodeError):
+            state["message"] = "Current kernel command line is unavailable."
+        return state
+
+    def _get_backup_path(self):
+        if self.runtime_dir is None:
+            raise SleepFixConfigurationError("DeckyZone runtime directory is unavailable.")
+        return self.runtime_dir / ORIGINAL_GRUB_BACKUP_FILENAME
+
+    def _atomic_write(self, path, contents, mode=None, owner=None):
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_path = tempfile.mkstemp(
+            prefix=f".{path.name}.deckyzone-", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(contents)
+                handle.flush()
+                os.fsync(handle.fileno())
+            if mode is not None:
+                os.chmod(temporary_path, stat.S_IMODE(mode))
+            if owner is not None and hasattr(os, "chown"):
+                os.chown(temporary_path, owner.st_uid, owner.st_gid)
+            os.replace(temporary_path, path)
+        except Exception:
+            try:
+                os.unlink(temporary_path)
+            except FileNotFoundError:
+                pass
+            raise
+
+    def _store_original_backup(self, original_contents):
+        backup_path = self._get_backup_path()
+        if backup_path.exists():
+            if backup_path.is_file() and not backup_path.is_symlink():
+                return
+            raise SleepFixConfigurationError(
+                "DeckyZone GRUB backup path is not a regular file."
+            )
+        self._atomic_write(backup_path, original_contents)
+
+    def apply_iommu_disabled(self, disabled):
+        original_defaults = self._read_grub_defaults()
+        updated_defaults, changed = set_amd_iommu_disabled(original_defaults, disabled)
+        if not changed:
+            return False
+
+        try:
+            original_config = self.grub_config_path.read_bytes()
+            default_stat = self.grub_default_path.stat()
+            config_stat = self.grub_config_path.stat()
+        except OSError as error:
+            raise SleepFixConfigurationError(
+                f"Failed to snapshot existing GRUB files: {error}"
+            ) from error
+
+        self._store_original_backup(original_defaults.encode("utf-8"))
+        self._atomic_write(
+            self.grub_default_path,
+            updated_defaults.encode("utf-8"),
+            mode=default_stat.st_mode,
+            owner=default_stat,
+        )
+        try:
+            self.command_runner(
+                [str(self.grub_mkconfig_path), "-o", str(self.grub_config_path)],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=self.env,
+            )
+        except Exception as error:
+            rollback_errors = []
+            try:
+                self._atomic_write(
+                    self.grub_default_path,
+                    original_defaults.encode("utf-8"),
+                    mode=default_stat.st_mode,
+                    owner=default_stat,
+                )
+            except Exception as rollback_error:
+                rollback_errors.append(f"defaults: {rollback_error}")
+            try:
+                self._atomic_write(
+                    self.grub_config_path,
+                    original_config,
+                    mode=config_stat.st_mode,
+                    owner=config_stat,
+                )
+            except Exception as rollback_error:
+                rollback_errors.append(f"generated config: {rollback_error}")
+
+            detail = "; ".join(rollback_errors)
+            if detail:
+                raise SleepFixConfigurationError(
+                    f"Failed to regenerate SteamOS GRUB configuration ({error}); rollback failed for {detail}."
+                ) from error
+            raise SleepFixConfigurationError(
+                f"Failed to regenerate SteamOS GRUB configuration: {error}"
+            ) from error
+
+        return True

--- a/src/components/PowerPanel.tsx
+++ b/src/components/PowerPanel.tsx
@@ -1,0 +1,94 @@
+import { callable } from '@decky/api'
+import { ButtonItem, Field, PanelSection, PanelSectionRow, ToggleField } from '@decky/ui'
+import { useState } from 'react'
+import type { PluginSettings } from '../types/plugin'
+import { useDeckyToastNotice } from '../utils/toasts'
+
+type Props = {
+  settings: PluginSettings
+  onSettingsChange: (nextSettings: PluginSettings) => void
+}
+
+const setFixSleepEnabled = callable<[boolean], PluginSettings>('set_fix_sleep_enabled')
+
+function getIommuStatus(settings: PluginSettings) {
+  const { sleepFix } = settings
+  if (!sleepFix.available) {
+    return 'Unavailable'
+  }
+  if (sleepFix.status === 'configuration_drift') {
+    return 'Configuration needs repair'
+  }
+  if (sleepFix.status === 'pending_reboot') {
+    return 'Pending restart'
+  }
+  if (sleepFix.runtimeIommuDisabled === false) {
+    return 'Not disabled for this boot'
+  }
+  if (sleepFix.runtimeIommuDisabled === true) {
+    return 'Disabled for this boot'
+  }
+  return 'Unknown'
+}
+
+const PowerPanel = ({ settings, onSettingsChange }: Props) => {
+  const [saving, setSaving] = useState(false)
+  const [notice, setNotice] = useState<{ body: string; severity: 'error' | 'success' } | null>(null)
+  const { sleepFix } = settings
+
+  useDeckyToastNotice(
+    notice
+      ? {
+          activeKey: `${notice.severity}:${notice.body}`,
+          title: 'Fix Sleep',
+          ...notice,
+        }
+      : null,
+  )
+
+  const applyFixSleep = async (enabled: boolean) => {
+    setSaving(true)
+    setNotice(null)
+    try {
+      const nextSettings = await setFixSleepEnabled(enabled)
+      onSettingsChange(nextSettings)
+      setNotice({
+        body: enabled ? 'Restart required to apply the AMD IOMMU change.' : 'Restart required to restore the AMD IOMMU setting.',
+        severity: 'success',
+      })
+    } catch (error) {
+      const message = error instanceof Error && error.message ? error.message : "Couldn't update Fix Sleep."
+      setNotice({ body: message, severity: 'error' })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <PanelSection title="Power">
+      <PanelSectionRow>
+        <ToggleField
+          label="Fix Sleep"
+          checked={sleepFix.enabled}
+          onChange={(value: boolean) => void applyFixSleep(value)}
+          disabled={saving || !sleepFix.available}
+          description="Enables AMD IOMMU to improve deep sleep on ZOTAC ZONE. Restart required."
+        />
+      </PanelSectionRow>
+      <PanelSectionRow>
+        <Field focusable disabled label="AMD IOMMU" description={sleepFix.message}>
+          {getIommuStatus(settings)}
+        </Field>
+      </PanelSectionRow>
+      {sleepFix.enabled && sleepFix.status === 'configuration_drift' && (
+        <PanelSectionRow>
+          <ButtonItem layout="below" onClick={() => void applyFixSleep(true)} disabled={saving}>
+            Reapply Fix
+          </ButtonItem>
+        </PanelSectionRow>
+      )}
+    </PanelSection>
+  )
+}
+
+export default PowerPanel

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,6 +11,7 @@ import ControllerPanel from "./components/ControllerPanel"
 import DisplayPanel from "./components/DisplayPanel"
 import ErrorBoundary from "./components/ErrorBoundary"
 import InterfacePanel from "./components/InterfacePanel"
+import PowerPanel from "./components/PowerPanel"
 import QuickAccessTitleView from "./components/QuickAccessTitleView"
 import TroubleshootingPanel from "./components/TroubleshootingPanel"
 import UpdatesPanel from "./components/UpdatesPanel"
@@ -436,6 +437,12 @@ function Content() {
       </ErrorBoundary>
       <ErrorBoundary title="Display">
         <DisplayPanel
+          settings={settings}
+          onSettingsChange={applySettingsUpdate}
+        />
+      </ErrorBoundary>
+      <ErrorBoundary title="Power">
+        <PowerPanel
           settings={settings}
           onSettingsChange={applySettingsUpdate}
         />

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -19,6 +19,16 @@ export type GyroMountMatrixFixState = {
   managedOverrideHasMatrix: boolean
 }
 
+export type SleepFixState = {
+  enabled: boolean
+  available: boolean
+  configuredIommuDisabled: boolean | null
+  runtimeIommuDisabled: boolean | null
+  rebootRequired: boolean
+  status: 'unavailable' | 'configuration_drift' | 'pending_reboot' | 'active' | 'disabled' | 'configured'
+  message: string
+}
+
 export type CleanupStepResult = {
   name: string
   ok: boolean
@@ -130,6 +140,7 @@ export type PluginSettings = {
   controllerModeAvailable: boolean
   homeButtonEnabled: boolean
   brightnessDialFixEnabled: boolean
+  sleepFix: SleepFixState
   gyroMountMatrixFix: GyroMountMatrixFixState
   trackpadMode: TrackpadMode
   zotacGlyphsEnabled: boolean

--- a/tests/test_steamos_sleep_fix.py
+++ b/tests/test_steamos_sleep_fix.py
@@ -1,9 +1,68 @@
+import asyncio
 import os
 import stat
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 
+
+# Minimal Decky Loader stubs required to import main.py in unit tests.
+decky = types.ModuleType("decky")
+decky.DECKY_PLUGIN_VERSION = "test"
+class TestLogger:
+    def warning(self, message):
+        pass
+
+    def info(self, message):
+        pass
+
+    def debug(self, message):
+        pass
+
+    def error(self, message):
+        pass
+
+
+decky.logger = TestLogger()
+decky.DECKY_USER_HOME = "."
+decky.DECKY_PLUGIN_DIR = "."
+decky.DECKY_PLUGIN_RUNTIME_DIR = "."
+sys.modules["decky"] = decky
+
+settings = types.ModuleType("settings")
+
+
+class SettingsManager:
+    def __init__(self, *args, **kwargs):
+        self.settings = {}
+
+    def read(self):
+        return self.settings
+
+    def setSetting(self, name, value):
+        self.settings[name] = value
+
+    def commit(self):
+        pass
+
+class FakeGamescopeDisplayProfiles:
+    def get_state(self):
+        return {
+            "gamescopeZotacProfileBuiltIn": False,
+            "gamescopeZotacProfileInstalled": False,
+            "gamescopeGreenTintFixEnabled": False,
+            "gamescopeZotacProfileTargetPath": "",
+            "gamescopeZotacProfileVerificationState": "absent",
+        }
+
+settings.SettingsManager = SettingsManager
+sys.modules["settings"] = settings
+
+os.environ["DECKY_PLUGIN_SETTINGS_DIR"] = "."
+
+import main
 import steamos_sleep_fix
 
 
@@ -20,6 +79,69 @@ audit=0 \\
 "
 '''
 
+class FakeSettingsStore:
+    def __init__(self, fix_sleep_enabled=False, original_iommu_disabled=None):
+        self.fix_sleep_enabled = fix_sleep_enabled
+        self.original_iommu_disabled = original_iommu_disabled
+
+    def get_fix_sleep_enabled(self):
+        return self.fix_sleep_enabled
+
+    def set_fix_sleep_enabled(self, enabled):
+        self.fix_sleep_enabled = bool(enabled)
+        return self.fix_sleep_enabled
+
+    def get_fix_sleep_original_amd_iommu_off(self):
+        return self.original_iommu_disabled
+
+    def set_fix_sleep_original_amd_iommu_off(self, disabled):
+        self.original_iommu_disabled = bool(disabled)
+        return self.original_iommu_disabled
+
+    def clear_fix_sleep_original_amd_iommu_off(self):
+        self.original_iommu_disabled = None
+
+    def get_startup_apply_enabled(self):
+        return False
+
+    def get_home_button_enabled(self):
+        return False
+
+    def get_brightness_dial_fix_enabled(self):
+        return False
+
+    def get_trackpad_mode(self):
+        return "default"
+
+    def get_zotac_glyphs_enabled(self):
+        return False
+
+    def get_rumble_enabled(self):
+        return False
+
+    def get_rumble_intensity(self):
+        return 75
+
+    def get_per_game_settings(self):
+        return {}
+
+class FakeSleepFix:
+    def __init__(self, config_iommu_disabled):
+        self.config_iommu_disabled = config_iommu_disabled
+        self.apply_calls = []
+
+    def get_state(self):
+        return {
+            "available": True,
+            "message": "",
+            "configIommuDisabled": self.config_iommu_disabled,
+            "runtimeIommuDisabled": self.config_iommu_disabled,
+        }
+
+    def apply_iommu_disabled(self, disabled):
+        self.apply_calls.append(bool(disabled))
+        self.config_iommu_disabled = bool(disabled)
+        return True
 
 class SteamOSSleepFixTests(unittest.TestCase):
     def test_enable_removes_all_iommu_off_arguments(self):
@@ -102,6 +224,81 @@ class SteamOSSleepFixTests(unittest.TestCase):
                 GRUB_DEFAULTS_WITH_OFF,
             )
 
+    def test_service_restores_original_iommu_disabled_state(self):
+        settings = FakeSettingsStore()
+        sleep_fix = FakeSleepFix(config_iommu_disabled=True)
+
+        service = main.DeckyZoneService.__new__(main.DeckyZoneService)
+        service.settings_store = settings
+        service.sleep_fix = sleep_fix
+        service.gamescope_display_profiles = FakeGamescopeDisplayProfiles()
+        service.logger = main.decky.logger
+        service._inputplumber_available = False
+        service._rumble_available = False
+
+        service._get_controller_mode_snapshot = lambda: {
+            "mode": "gamepad",
+            "available": True,
+        }
+
+        service._get_gyro_mount_matrix_fix_state = lambda: {
+            "available": False,
+            "enabled": False,
+        }
+
+        asyncio.run(service.set_fix_sleep_enabled(True))
+
+        self.assertTrue(settings.get_fix_sleep_enabled())
+        self.assertTrue(
+            settings.get_fix_sleep_original_amd_iommu_off()
+        )
+        self.assertEqual(sleep_fix.apply_calls, [False])
+
+        asyncio.run(service.set_fix_sleep_enabled(False))
+
+        self.assertFalse(settings.get_fix_sleep_enabled())
+        self.assertIsNone(
+            settings.get_fix_sleep_original_amd_iommu_off()
+        )
+        self.assertEqual(sleep_fix.apply_calls, [False, True])
+
+    def test_service_restores_original_iommu_enabled_state(self):
+        settings = FakeSettingsStore()
+        sleep_fix = FakeSleepFix(config_iommu_disabled=False)
+
+        service = main.DeckyZoneService.__new__(main.DeckyZoneService)
+        service.settings_store = settings
+        service.sleep_fix = sleep_fix
+        service.gamescope_display_profiles = FakeGamescopeDisplayProfiles()
+        service.logger = main.decky.logger
+        service._inputplumber_available = False
+        service._rumble_available = False
+
+        service._get_controller_mode_snapshot = lambda: {
+            "mode": "gamepad",
+            "available": True,
+        }
+
+        service._get_gyro_mount_matrix_fix_state = lambda: {
+            "available": False,
+            "enabled": False,
+        }
+
+        asyncio.run(service.set_fix_sleep_enabled(True))
+
+        self.assertTrue(settings.get_fix_sleep_enabled())
+        self.assertFalse(
+            settings.get_fix_sleep_original_amd_iommu_off()
+        )
+        self.assertEqual(sleep_fix.apply_calls, [False])
+
+        asyncio.run(service.set_fix_sleep_enabled(False))
+
+        self.assertFalse(settings.get_fix_sleep_enabled())
+        self.assertIsNone(
+            settings.get_fix_sleep_original_amd_iommu_off()
+        )
+        self.assertEqual(sleep_fix.apply_calls, [False, False])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_steamos_sleep_fix.py
+++ b/tests/test_steamos_sleep_fix.py
@@ -1,0 +1,107 @@
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+import steamos_sleep_fix
+
+
+GRUB_DEFAULTS_WITH_OFF = '''GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} \\
+log_buf_len=4M \\
+amd_iommu=off \\
+audit=0 \\
+"
+'''
+
+GRUB_DEFAULTS_WITHOUT_OFF = '''GRUB_CMDLINE_LINUX="${GRUB_CMDLINE_LINUX} \\
+log_buf_len=4M \\
+audit=0 \\
+"
+'''
+
+
+class SteamOSSleepFixTests(unittest.TestCase):
+    def test_enable_removes_all_iommu_off_arguments(self):
+        updated, changed = steamos_sleep_fix.set_amd_iommu_disabled(
+            GRUB_DEFAULTS_WITH_OFF, False
+        )
+
+        self.assertTrue(changed)
+        self.assertNotIn("amd_iommu=off", updated)
+
+    def test_enable_is_idempotent_when_iommu_off_is_absent(self):
+        updated, changed = steamos_sleep_fix.set_amd_iommu_disabled(
+            GRUB_DEFAULTS_WITHOUT_OFF, False
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(updated, GRUB_DEFAULTS_WITHOUT_OFF)
+
+    def test_disable_adds_one_iommu_off_argument(self):
+        updated, changed = steamos_sleep_fix.set_amd_iommu_disabled(
+            GRUB_DEFAULTS_WITHOUT_OFF, True
+        )
+
+        self.assertTrue(changed)
+        self.assertEqual(updated.count("amd_iommu=off"), 1)
+
+    def test_disable_is_idempotent_when_one_iommu_off_argument_exists(self):
+        updated, changed = steamos_sleep_fix.set_amd_iommu_disabled(
+            GRUB_DEFAULTS_WITH_OFF, True
+        )
+
+        self.assertFalse(changed)
+        self.assertEqual(updated, GRUB_DEFAULTS_WITH_OFF)
+
+    def test_rejects_an_unexpected_grub_assignment(self):
+        with self.assertRaises(steamos_sleep_fix.SleepFixConfigurationError):
+            steamos_sleep_fix.set_amd_iommu_disabled('GRUB_CMDLINE_LINUX="quiet"\n', False)
+
+    def test_failed_generation_restores_both_grub_files(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            os_release_path = root / "os-release"
+            defaults_path = root / "grub-steamos"
+            generated_path = root / "grub.cfg"
+            mkconfig_path = root / "grub-mkconfig"
+            runtime_dir = root / "runtime"
+
+            os_release_path.write_text('ID="steamos"\n', encoding="utf-8")
+            defaults_path.write_text(GRUB_DEFAULTS_WITH_OFF, encoding="utf-8")
+            generated_path.write_text("previous generated config\n", encoding="utf-8")
+            mkconfig_path.write_text("placeholder", encoding="utf-8")
+            mkconfig_path.chmod(mkconfig_path.stat().st_mode | stat.S_IXUSR)
+
+            def failing_runner(args, **kwargs):
+                generated_path.write_text("partial generated config\n", encoding="utf-8")
+                raise RuntimeError("grub-mkconfig failed")
+
+            sleep_fix = steamos_sleep_fix.SteamOSSleepFix(
+                command_runner=failing_runner,
+                runtime_dir=runtime_dir,
+                os_release_paths=(os_release_path,),
+                grub_default_path=defaults_path,
+                grub_config_path=generated_path,
+                grub_mkconfig_path=mkconfig_path,
+            )
+
+            with self.assertRaises(steamos_sleep_fix.SleepFixConfigurationError):
+                sleep_fix.apply_iommu_disabled(False)
+
+            self.assertEqual(
+                defaults_path.read_text(encoding="utf-8"), GRUB_DEFAULTS_WITH_OFF
+            )
+            self.assertEqual(
+                generated_path.read_text(encoding="utf-8"), "previous generated config\n"
+            )
+            self.assertEqual(
+                (runtime_dir / steamos_sleep_fix.ORIGINAL_GRUB_BACKUP_FILENAME).read_text(
+                    encoding="utf-8"
+                ),
+                GRUB_DEFAULTS_WITH_OFF,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview

Adds a new **Fix Sleep** toggle for SteamOS on ZOTAC ZONE devices.

SteamOS configures the kernel with `amd_iommu=off`, which prevents the ZOTAC ZONE from reaching deep S0ix sleep. This fix removes that GRUB parameter and regenerates the SteamOS GRUB configuration.

The fix is fully reversible and preserves the original IOMMU state, so disabling the feature restores the state that was present before the fix was enabled rather than unconditionally forcing `amd_iommu=off`.

## What it does

- Adds a **Fix Sleep** toggle to the Power panel.
- Validates the expected SteamOS GRUB configuration before modifying it.
- Removes `amd_iommu=off` when the fix is enabled.
- Regenerates the SteamOS GRUB configuration.
- Stores the original IOMMU configuration for safe restoration.
- Restores the original configuration when the fix is disabled.
- Detects configuration drift, including SteamOS updates that restore `amd_iommu=off`.
- Provides an explicit reapply action when the configuration no longer matches the requested state.
- Uses atomic writes and rolls back both the source and generated GRUB configuration if regeneration fails.

## Validation

Tested on a ZOTAC ZONE running SteamOS.

Before applying the fix:

- `amd_iommu=off` was present in `/proc/cmdline`.
- After suspending the device, no S0ix residency was recorded.

After removing `amd_iommu=off` and rebooting:

- AMD IOMMU was active.
- A real suspend of approximately 90 seconds produced S0ix residency.

The change was also reversed and `amd_iommu=off` restored, reproducing the previous sleep behavior.

## Tests

Added backend tests covering:

- AMD IOMMU parameter parsing and modification.
- Idempotent configuration changes.
- GRUB generation failure rollback.
- Restoration of the original IOMMU-disabled state.
- Restoration of the original IOMMU-enabled state.

All 8 tests pass.